### PR TITLE
Add JSON export option to save dialog

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react'
 import { confirm } from '@tauri-apps/plugin-dialog'
 import { trace, error } from '@tauri-apps/plugin-log'
 import { extname } from '@tauri-apps/api/path'
+import { copyFile } from '@tauri-apps/plugin-fs'
 
 import Sidebar from './components/Sidebar'
 import InfoBanner from './components/InfoBanner'
@@ -111,9 +112,10 @@ function App() {
       // First, save the JSON mapping to the working temp path
       if (!(await saveMappingJsonToDisk(workingFileCurrent.tempJsonPath, jsonMapping))) {
         errorAndInfo('Could not serialize in-memory json to disk.')
+        return
       }
 
-      // Ask user where to save the save file (either .sav or no extension)
+      // Ask user where to export the game save or JSON file.
       let currentFileExt: string | null = null
       try {
         const ext = await extname(workingFileCurrent.originalSavPath)
@@ -142,11 +144,23 @@ function App() {
             name: `Export File`,
             extensions: currentFileExt ? [currentFileExt] : [],
           },
+          {
+            name: 'JSON File',
+            extensions: ['json'],
+          },
         ],
       })
 
       if (!targetSavPath) {
         errorAndInfo('Export canceled or no target save path selected.')
+        return
+      }
+
+      if (/\.json$/i.test(targetSavPath)) {
+        await copyFile(workingFileCurrent.tempJsonPath, targetSavPath)
+        const message = `JSON successfully exported to ${targetSavPath}`
+        setInfoMessage(message)
+        trace(message)
         return
       }
 

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -171,7 +171,7 @@ const Sidebar: FC<SidebarProps> = ({
           disabled={!anyFileOpen}
           style={{ width: '49%', marginRight: '2%' }}
           title={anyFileOpen
-            ? 'Export a file to wherever you want.\nYou will be prompted for the target destination.'
+            ? 'Export a game save or JSON file.\nChoose the format and destination in the save dialog.'
             : "Open a file before trying to export it\nIt's just over this button"}
         >
           Export


### PR DESCRIPTION
Adds a JSON option to the existing Export dialog so users can export the current edited mapping for inspection or use in other tools.

Related to #12. This implements the export part of that request; JSON import is still outside this change.

- Destinations ending in `.json` (case-insensitive) receive the serialized mapping directly, using the existing filesystem plugin.
- Other destinations continue through the existing game-save conversion flow.
- Export stops if serialization fails, preventing a stale temporary file from being exported.
- The Export tooltip explains the format choice. JSON export retains the pending game-save changes indicator.

Validation: `npm run build` (TypeScript + Vite) and `git diff --check` passed. Vite reports warnings about mixed static/dynamic dialog imports and bundle size. Native save-dialog and filesystem behavior has not been manually tested on Windows/Linux in this pass.

Suggested manual check: open a disposable save, make an edit, export to `.json`, and verify the edited value in the output. Also check normal save export, cancellation, and an unwritable destination.